### PR TITLE
batteryReader was still being initialized

### DIFF
--- a/app/src/main/java/com/sqisland/espresso/battery/MainActivity.java
+++ b/app/src/main/java/com/sqisland/espresso/battery/MainActivity.java
@@ -22,7 +22,6 @@ public class MainActivity extends AppCompatActivity {
         refresh();
       }
     });
-    batteryReader = new BatteryReader(this);
 
     inject();
   }


### PR DESCRIPTION
Reading through the book (thanks!) and noticed that in this branch the batteryReader was still being assigned in `onCreate` (line 25).
I removed this locally and seemed to work fine since it's being injected later on.
Sorry, trying to re-remember how DI works (previously a veteran of the Spring/JEE wars of the early 00s) ;)
